### PR TITLE
fix portable, check & cache path

### DIFF
--- a/ParsecSoda/Core/Cache.cpp
+++ b/ParsecSoda/Core/Cache.cpp
@@ -151,7 +151,7 @@ void Cache::banIPAddress(std::string ip) {
 	}
 
 	// Save the file
-	string ipPath = PathHelper::GetConfigPath() + "\\banned_ip.json";
+	string ipPath = PathHelper::GetConfigPath() + "banned_ip.json";
 	string ipString = j.dump(4);
 	bool success = MTY_WriteTextFile(ipPath.c_str(), "%s", ipString.c_str());
 
@@ -175,7 +175,7 @@ void Cache::unbanIPAddress(std::string ip) {
 	}
 
 	// Save the file
-	string ipPath = PathHelper::GetConfigPath() + "\\banned_ip.json";
+	string ipPath = PathHelper::GetConfigPath() + "banned_ip.json";
 	string ipString = j.dump(4);
 	bool success = MTY_WriteTextFile(ipPath.c_str(), "%s", ipString.c_str());
 }
@@ -215,7 +215,7 @@ std::string Cache::getUserIpAddress(uint32_t userId) {
 void Cache::LoadBannedIpAddresses() {
 
     // Load banned IP addresses
-	string ipPath = PathHelper::GetConfigPath() + "\\banned_ip.json";
+	string ipPath = PathHelper::GetConfigPath() + "banned_ip.json";
 	if (MTY_FileExists(ipPath.c_str())) {
 
 		try {

--- a/ParsecSoda/Core/Config.cpp
+++ b/ParsecSoda/Core/Config.cpp
@@ -10,7 +10,7 @@ Config Config::cfg;
 void Config::Load() {
 
 	// Get the config path
-	string configPath = PathHelper::GetConfigPath() + "\\config.json";
+	string configPath = PathHelper::GetConfigPath() + "config.json";
 	if (MTY_FileExists(configPath.c_str())) {
 
 		try {
@@ -379,7 +379,7 @@ void Config::Save() {
 	if (configPath != "") {
 
 		// Filepath
-		string filePath = configPath + "\\config.json";
+		string filePath = configPath + "config.json";
 
 		string configString = j.dump(4);
 		bool success = MTY_WriteTextFile(filePath.c_str(), "%s", configString.c_str());

--- a/ParsecSoda/Helpers/PathHelper.cpp
+++ b/ParsecSoda/Helpers/PathHelper.cpp
@@ -4,24 +4,37 @@
  * Gets the path to the Smash Soda config.json file.
  */
 string PathHelper::GetConfigPath() {
-	
+	static string cachedConfigPath = "";
+	if (!cachedConfigPath.empty()) return cachedConfigPath;
+
+	string dirPath = "";
+	string appDir = "\\SmashSodaTwo\\";
+
 	// If running in portable mode
 	string currentPath = PathHelper::GetCurrentPath();
-	if (MTY_FileExists((currentPath + "\\portable.txt").c_str())) {
-		return currentPath;
+	if (MTY_FileExists(string(currentPath + "\\portable.txt").c_str())) {
+		dirPath = currentPath + appDir;
 	} else {
 
 		// Get the appdata path
 		string appDataPath = PathHelper::GetAppDataPath();
-		if (appDataPath != "") {
-			return appDataPath;
+		if (!appDataPath.empty()) {
+			dirPath = appDataPath + appDir;
 		} else {
 			return "";
 		}
-
 	}
 
-	return "";
+	bool isDirOk = false;
+	if (!MTY_FileExists(dirPath.c_str())) {
+		if (MTY_Mkdir(dirPath.c_str())) {
+			isDirOk = true;
+		}
+	}
+	else isDirOk = true;
+	if (isDirOk) cachedConfigPath = dirPath;
+
+	return dirPath;
 }
 
 /**
@@ -38,30 +51,14 @@ string PathHelper::GetCurrentPath() {
 }
 
 /**
- * Get the path to the Smash Soda appdata directory.
+ * Get the path to AppData directory. (Not AppData/SmashSoda/)
  */
 string PathHelper::GetAppDataPath() {
-	string appDir = "\\SmashSodaTwo\\";
-
 	TCHAR tAppdata[1024];
 	if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_APPDATA, NULL, 0, tAppdata))) {
 		wstring wAppdata(tAppdata);
-		string appdata(wAppdata.begin(), wAppdata.end());
-		string dirPath = appdata + appDir;
-
-		bool isDirOk = false;
-
-		if (!MTY_FileExists(dirPath.c_str())) {
-			if (MTY_Mkdir(dirPath.c_str())) {
-				isDirOk = true;
-			}
-		} else {
-			isDirOk = true;
-		}
-
-		if (isDirOk) {
-			return dirPath;
-		}
+		string dirPath(wAppdata.begin(), wAppdata.end());
+		return dirPath;
 	}
 }
 

--- a/ParsecSoda/ParsecSession.cpp
+++ b/ParsecSoda/ParsecSession.cpp
@@ -176,12 +176,12 @@ const ParsecSession::SessionStatus ParsecSession::pollSession(ParsecSession::Aut
 const bool ParsecSession::fetchSession(const char* email, const char* password, const char* tfa)
 {
 	// Body
-	ostringstream ss;
-	ss << "{"
-		<< "\"" << "email" << "\":\"" << email << "\","
-		<< "\"" << "password" << "\":\"" << password << "\","
-		<< "\"" << "tfa" << "\":\"" << tfa << "\"}";
-	const string bodyString = ss.str();
+	json jsonBody = {
+		{"email", email},
+		{"password", password},
+		{"tfa", tfa}
+	};
+	const string bodyString = jsonBody.dump();
 	const char* body = bodyString.c_str();
 	size_t bodySize = sizeof(char) * bodyString.length();
 

--- a/ParsecSoda/ParsecSession.h
+++ b/ParsecSoda/ParsecSession.h
@@ -9,6 +9,8 @@
 #include "GuestList.h"
 #include "MetadataCache.h"
 #include "Helpers/Clock.h"
+#include "nlohmann/json.hpp"
+using json = nlohmann::json;
 
 #define SESSION_LIFETIME (uint32_t)(HOURS(1) + MINUTES(25))
 


### PR DESCRIPTION
With these changes, portable now stores all configs in /app/SmashSodaTwo/ just like normal would use AppData/SmashSodaTwo
This makes it  just easy to copy the folder to either location.